### PR TITLE
Remove redundant license specification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![license = "MIT"]
 #![deny(missing_docs, warnings)]
 #![feature(phase, globs)]
 


### PR DESCRIPTION
The license is already defined in Cargo.toml and the `license` attribute
is picked up as an unused attribute by rustc, causing #[deny(warnings)]
to fail the compilation because of the unused attribute warning
