### PR TITLE
(fix) Make Set inherit Sized

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub trait Modifier<F> {
 ///
 /// Simply implement this for your types and they can be used
 /// with modifiers.
-pub trait Set {
+pub trait Set : Sized {
     /// Modify self using the provided modifier.
     #[inline(always)]
     fn set<M: Modifier<Self>>(mut self, modifier: M) -> Self {


### PR DESCRIPTION
In the current-rust nightly the project failed to build due to Set not
implementing Sized.

I'm new to rust and unsure if this is the way to go.

rustc 0.13.0-nightly (c6c786671 2015-01-04 00:50:59 +0000)
cargo 0.0.1-pre-nightly (4657875 2015-01-03 23:29:22 +0000)