### PR TITLE
Add `impl Modifier for ()`

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -4,6 +4,11 @@
 
 use Modifier;
 
+impl<X> Modifier<X> for () {
+    fn modify(self, _: &mut X) {
+    }
+}
+
 impl<X, M1> Modifier<X> for (M1,)
 where M1: Modifier<X> {
     fn modify(self, x: &mut X) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,12 @@ mod test {
     }
 
     #[test]
+    fn test_empty_tuple() {
+        let thing = Thing { x: 8 }.set(());
+        assert_eq!(thing.x, 8);
+    }
+
+    #[test]
     fn test_tuple_chains() {
         let thing = Thing { x: 8 }.set((ModifyX(5), ModifyX(112)));
         assert_eq!(thing.x, 112);


### PR DESCRIPTION
This allows for null modifiers which can be useful when you may want to decide whether to return a modifier or not at either compile or run time. Runtime deciding will also need PR #20 to allow returning different types boxed, compile time deciding through `cfg` attributes works now.
