### PR TITLE
Boxed modifiers

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -2,7 +2,7 @@
 ///
 /// FIXME(reem): Move generation of this to a build script.
 
-use Modifier;
+use { Modifier, ModifierBox };
 
 impl<X, M1> Modifier<X> for (M1,)
 where M1: Modifier<X> {
@@ -83,5 +83,19 @@ where M: Modifier<X> {
             Some(m) => m.modify(x),
             None => (),
         }
+    }
+}
+
+impl<X, M: ?Sized> Modifier<X> for Box<M>
+where M: ModifierBox<X> {
+    fn modify(self, x: &mut X) {
+        self.modify_box(x)
+    }
+}
+
+impl<X, M> ModifierBox<X> for M
+where M: Modifier<X> {
+    fn modify_box(self: Box<Self>, x: &mut X) {
+        (*self).modify(x);
     }
 }


### PR DESCRIPTION
Unfortunately this is a breaking change to allow unsized modifiers, :crying_cat_face:. I haven't actually checked the output but since `Set::set` is inlined the referencing for modify should be optimised out completely. Main reason for this is to allow choosing different modifiers at runtime.
