### PR TITLE
Add `impl Modifier for Option<Modifier>`

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -75,3 +75,13 @@ where M1: Modifier<X>,
         self.5.modify(x);
     }
 }
+
+impl<X, M> Modifier<X> for Option<M>
+where M: Modifier<X> {
+    fn modify(self, x: &mut X) {
+        match self {
+            Some(m) => m.modify(x),
+            None => (),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,16 @@ mod test {
     }
 
     #[test]
+    fn test_optional_modifier() {
+        let get_mod = |b| if b { Some(ModifyX(5)) } else { None };
+        let thing = Thing { x: 8 }.set(get_mod(false));
+        assert_eq!(thing.x, 8);
+
+        let thing = thing.set(get_mod(true));
+        assert_eq!(thing.x, 5);
+    }
+
+    #[test]
     fn test_tuple_chains() {
         let thing = Thing { x: 8 }.set((ModifyX(5), ModifyX(112)));
         assert_eq!(thing.x, 112);


### PR DESCRIPTION
An alternative to #19 + #20 for runtime deciding whether to apply a modifier, but I think it would be useful to have both. #20 also allows for choosing between 2+ alternatives instead of just turning a modifier on or off.
